### PR TITLE
fix: Support Cabal 3.18

### DIFF
--- a/cabal-doctest.cabal
+++ b/cabal-doctest.cabal
@@ -55,7 +55,7 @@ library
     -- In any case, revisions may set tighter bounds afterwards, if exceptional
     -- circumstances would warrant that.
       base       >=4.9  && <5
-    , Cabal      >=1.24 && <3.17
+    , Cabal      >=1.24 && <3.19
     , directory  >=1.3  && <2
     , filepath   >=1.4  && <2
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 1.0.13 -- Unreleased
+
+* Support Cabal 3.18.0.0.
+
 # 1.0.12 -- 2025-11-19
 
 * Fix documentation mistake regarding `Build_doctests` module name. [cabal-doctest#90][]

--- a/src/Distribution/Extra/Doctest.hs
+++ b/src/Distribution/Extra/Doctest.hs
@@ -138,6 +138,13 @@ import Distribution.Utils.Path
        (getSymbolicPath)
 #endif
 
+#if MIN_VERSION_Cabal(3,17,0)
+import Distribution.Verbosity
+       (mkVerbosity, defaultVerbosityHandles, VerbosityFlags, Verbosity)
+import Distribution.Simple.Flag
+       (Flag)
+#endif
+
 #if MIN_VERSION_Cabal(3,14,0)
 -- https://github.com/haskell/cabal/issues/10559
 import Distribution.Simple.Compiler
@@ -216,6 +223,21 @@ findFileEx _ = findFile
 mkVersion :: [Int] -> Version
 mkVersion ds = Version ds []
 #endif
+
+-- Taken from Cabal: https://github.com/haskell/cabal/blob/master/changelog.d/pr-11077
+mkVerbosityCompat
+  ::
+#if MIN_VERSION_Cabal(3,17,0)
+    Flag VerbosityFlags
+#else
+    Flag Verbosity
+#endif
+  -> Verbosity
+mkVerbosityCompat v =
+#if MIN_VERSION_Cabal(3,17,0)
+  mkVerbosity defaultVerbosityHandles $
+#endif
+  fromFlag v
 
 -------------------------------------------------------------------------------
 -- Mains
@@ -333,7 +355,7 @@ generateBuildModule
     :: TestSuiteName
     -> BuildFlags -> PackageDescription -> LocalBuildInfo -> IO ()
 generateBuildModule testSuiteName flags pkg lbi = do
-  let verbosity = fromFlag (buildVerbosity flags)
+  let verbosity = mkVerbosityCompat (buildVerbosity flags)
   let distPref = fromFlag (buildDistPref flags)
 
   -- Package DBs & environments


### PR DESCRIPTION
The Cabal development head (v3.17) made changes to the structure of the Verbosity type. The change is poised to be released in Cabal 3.18.

See https://github.com/haskell/cabal/blob/master/changelog.d/pr-11077 for migration guide.

---
Unfortunately I wasn't able to test the change with `simple-example` or `multiple-components-example` as I'm having some trouble with the build due to dependency resolution (I'm seeing conflicts likely due to `process` package being incompatible with development Cabal version). However, when the `cabal-doctest` library is built as part of another project, the build succeeds.

I'm not expecting this patch to be merged before Cabal 3.18 is released, but I'm putting it out now so that you can become aware of the upcoming change in Cabal.